### PR TITLE
fix: map details layerbutton labels are cut off on smaller screens

### DIFF
--- a/src/components/MTMLView/MTMLView.tsx
+++ b/src/components/MTMLView/MTMLView.tsx
@@ -145,7 +145,7 @@ const styles: IStyles = {
   card: (theme: Theme) => ({
     [theme.breakpoints.up("xs")]: {
       maxWidth: "100%",
-      height: "50vh",
+      height: "auto",
     },
     [theme.breakpoints.up("sm")]: {
       maxWidth: 290,


### PR DESCRIPTION
# Description



**discord username: bumshaqalaqa#2973**


**closes #20**
**closes #18**


One liner actually

