### PR TITLE
feat: remove mock field from ApiClient

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,1 +1,1 @@
-NEXT_PUBLIC_BASE_URL=https://backend.gonullu.io
+NEXT_PUBLIC_BASE_URL=https://backend.gonullu.io/mock

--- a/src/features/api-client/ApiClient.ts
+++ b/src/features/api-client/ApiClient.ts
@@ -54,30 +54,23 @@ const transformDetailResponse = (
 
 interface ApiClientProps {
   url?: string;
-  mock?: true;
 }
 
 export class ApiClient {
   readonly url: string;
-  readonly mock: boolean;
 
   constructor(props: ApiClientProps = {}) {
     this.url = props.url ?? API_URL;
-    this.mock = !!props.mock;
   }
 
   async fetchFeeds() {
-    const url = this.mock
-      ? new URL(this.url + "/feeds/mock")
-      : new URL(this.url + "/feeds");
+    const url = new URL(this.url + "/feeds");
     const data = await dataFetcher<ApiResponseFeeds>(url);
     return data ? data.results.map(transformResponse) : null;
   }
 
   async fetchDetail(id: string) {
-    const url = this.mock
-      ? new URL(this.url + "/feed/mock/" + id)
-      : new URL(this.url + "/feed/" + id);
+    const url = new URL(this.url + "/feed/" + id);
     const data = await dataFetcher<ApiResponseFeed>(url);
     return data ? transformDetailResponse(data) : null;
   }

--- a/src/features/singletons/store.ts
+++ b/src/features/singletons/store.ts
@@ -2,5 +2,5 @@ import { ApiClient } from "@/features/api-client";
 import { create } from "zustand";
 
 export const useSingletonsStore = create<{ api: ApiClient }>()(() => ({
-  api: new ApiClient({ mock: true }),
+  api: new ApiClient(),
 }));


### PR DESCRIPTION
We remove the mock field from api client because we manage it through NEXT_PUBLIC_BASE_URL env variable now.