### PR TITLE
intensity & heatmap fixes

### DIFF
--- a/src/components/Map/Content.tsx
+++ b/src/components/Map/Content.tsx
@@ -37,7 +37,7 @@ const transformToChannelData = ({
     name: neighborhood.name,
     description: null,
   },
-  intensity: intensity.intensity / 10 ?? DEFAULT_IMPORTANCY,
+  intensity: intensity.intensity ?? DEFAULT_IMPORTANCY,
   location: {
     lat: neighborhood.lat,
     lng: neighborhood.lng,

--- a/src/components/Map/LayerControl.tsx
+++ b/src/components/Map/LayerControl.tsx
@@ -44,13 +44,13 @@ export const LayerControl = ({ locations, onMarkerClick }: Props) => {
               key={idx}
               fitBoundsOnUpdate={false}
               fitBoundsOnLoad={false}
-              radius={15}
+              radius={30}
               max={5}
               points={points}
               longitudeExtractor={longitudeExtractor}
               latitudeExtractor={latitudeExtractor}
               intensityExtractor={intensityExtractor}
-              useLocalExtrema={false}
+              useLocalExtrema={true}
             />
           );
         }


### PR DESCRIPTION
We were calculating the marker intensity by dividing the real value to 10, causing our label calculations to fail because we expect them to be in the scale of 1-5

then i tweaked the heatmap settings to get better visualisations and it actually turned out pretty well with each zoom level. try it out in the preview link.

Closes #81 
Closes #90 